### PR TITLE
Make BiomeMapper able to recognize modded biomes.

### DIFF
--- a/src/main/java/vazkii/ambience/BiomeMapper.java
+++ b/src/main/java/vazkii/ambience/BiomeMapper.java
@@ -1,11 +1,12 @@
 package vazkii.ambience;
 
-import java.util.HashMap;
-import java.util.Map;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.common.BiomeDictionary.Type;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class BiomeMapper {
 	
@@ -15,13 +16,31 @@ public class BiomeMapper {
 		biomeMap = new HashMap<String, Biome>();
 		for(ResourceLocation biomeResource : Biome.REGISTRY.getKeys()) {
 			Biome biome = Biome.REGISTRY.getObject(biomeResource);
-			biomeMap.put(biome.getBiomeName(), biome);
+			String biomeName = biome.getBiomeName();
+			if (biomeResource.getResourceDomain() != "minecraft") {
+				biomeName = biomeResource.getResourceDomain()+" "+biomeName;
+			}
+			biomeMap.put(biomeName, biome);
 		}
+	}
+
+	public static Map<String, Biome> getBiomes() {
+		Map<String, Biome> tmpBiomeMap = new HashMap<String, Biome>();
+		for(ResourceLocation biomeResource : Biome.REGISTRY.getKeys()) {
+			Biome biome = Biome.REGISTRY.getObject(biomeResource);
+			String biomeName = biome.getBiomeName();
+			if (biomeResource.getResourceDomain() != "minecraft") {
+				biomeName = biomeResource.getResourceDomain()+" "+biomeName;
+			}
+			tmpBiomeMap.put(biomeName, biome);
+		}
+		return tmpBiomeMap;
 	}
 	
 	public static Biome getBiome(String s) {
-		if(biomeMap == null)
+		if(biomeMap == null) {
 			applyMappings();
+		}
 		return biomeMap.get(s);
 	}
 	

--- a/src/main/java/vazkii/ambience/SongLoader.java
+++ b/src/main/java/vazkii/ambience/SongLoader.java
@@ -1,27 +1,20 @@
 	package vazkii.ambience;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
-import java.util.Set;
+    import net.minecraft.world.biome.Biome;
+    import net.minecraftforge.common.BiomeDictionary;
+    import net.minecraftforge.fml.common.FMLLog;
+    import org.apache.logging.log4j.Level;
 
-import org.apache.logging.log4j.Level;
-
-import net.minecraft.world.biome.Biome;
-import net.minecraftforge.common.BiomeDictionary;
-import net.minecraftforge.fml.common.FMLLog;
+    import java.io.*;
+    import java.util.Properties;
+    import java.util.Set;
 
 public final class SongLoader {
 
 	public static File mainDir;
 	public static boolean enabled = false;
-	
+	public static boolean debug = false;
+
 	public static void loadFrom(File f) {
 		File config = new File(f, "ambience.properties");
 		if(!config.exists())
@@ -31,7 +24,9 @@ public final class SongLoader {
 		try {
 			props.load(new FileReader(config));
 			enabled = props.getProperty("enabled").equals("true");
-			
+			debug = props.getProperty("debug").equals("true");
+
+
 			if(enabled) {
 				SongPicker.reset();
 				Set<Object> keys = props.keySet();

--- a/src/main/java/vazkii/ambience/SongPicker.java
+++ b/src/main/java/vazkii/ambience/SongPicker.java
@@ -1,13 +1,5 @@
 package vazkii.ambience;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
-import java.util.UUID;
-
-import org.apache.commons.lang3.StringUtils;
-
 import net.minecraft.block.material.Material;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.BossInfoClient;
@@ -28,7 +20,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.TextComponentBase;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
@@ -38,6 +29,9 @@ import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.common.BiomeDictionary.Type;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.*;
 
 public final class SongPicker {
 
@@ -72,9 +66,15 @@ public final class SongPicker {
 	public static final Map<BiomeDictionary.Type, String[]> secondaryTagMap = new HashMap();
 	
 	public static final Random rand = new Random();
-	
+
 	public static void reset() {
 		eventMap.clear();
+		biomeMap.clear();
+		primaryTagMap.clear();
+		secondaryTagMap.clear();
+	}
+
+	public static void resetBiomes() {
 		biomeMap.clear();
 		primaryTagMap.clear();
 		secondaryTagMap.clear();


### PR DESCRIPTION
(Move config loading to "init" rather than "preinit", and handle possible duplicate Biome names.)

Add "debug" option to config. (To see all biomes, their names, as well as properly loaded event usages in the config through the game log when "true".)